### PR TITLE
update broken menu url

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -109,7 +109,7 @@ export default function Menu() {
       </StyledMenuButton>
       {open && (
         <MenuFlyout>
-          <MenuItem id="link" href="https://ubiq.ninja/dapps/shinobi">
+          <MenuItem id="link" href="https://ubiq.ninja/en/shinobi/about">
             <Info size={14} />
             About
           </MenuItem>


### PR DESCRIPTION
Current production version has link that resolves to 404 not found.
This change updates the link to https://ubiq.ninja/en/shinobi/about

**PLEASE DO NOT SUBMIT TOKEN ADDITIONS AS PULL REQUESTS**

All token requests should be made via an issue.
